### PR TITLE
Fix typo in defaults/main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,9 +10,9 @@ snmpd_groups:
   - name: notConfigGroup
     security_model: v1
     security_name: notConfigUser
-  - name: NotConfigGroup
+  - name: notConfigGroup
     security_model: v2c
-    security_name: NotConfigUser
+    security_name: notConfigUser
 
 snmpd_views:
   - name: systemview


### PR DESCRIPTION
There was a little typo in the snmpd_groups for v2c. That makes the v2c metrics not responding to telegraf snmp pluguin requests when using the default name values.

